### PR TITLE
modify script to use mono/curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+files/
+depotdownloader/

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ found
 ## Prerequisites
 
 - A fully updated Steam version of Doom Eternal
-- .NET Core: See [here](https://wiki.archlinux.org/index.php/.NET_Core) for more
-  information. Don't forget to add `~/.dotnet/tools` to your PATH.
+- Mono: See [here](https://wiki.archlinux.org/index.php/Mono) for more information.
 
 ## Config
 

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -28,6 +28,7 @@ unzip depotdownloader_2.3.4.zip
 
 # make depotdownloader executable
 chmod +x depotdownloader
+# replace dotnet dependency with mono
 sed -i 's/dotnet/mono/' depotdownloader
 
 # download the depots

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -22,13 +22,13 @@ mkdir -p $DOOMGRADER_ROOT $DOWNLOAD_PATH $DEPOTDOWNLOADER_PATH
 pushd $DEPOTDOWNLOADER_PATH
 
 # download depotdownloader
-wget https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/depotdownloader-2.3.4.zip -O depotdownloader_2.3.4.zip
-
+curl https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/depotdownloader-2.3.4.zip -o depotdownloader_2.3.4.zip -L
 # extract depotdownloader
 unzip depotdownloader_2.3.4.zip
 
 # make depotdownloader executable
 chmod +x depotdownloader
+sed -i 's/dotnet/mono/' depotdownloader
 
 # download the depots
 ./depotdownloader -app 782330 -depot 782332 -manifest 4641765937586464647 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"


### PR DESCRIPTION
Generally speaking, `mono` is more compatible (and available on more distributions, as it's not locked down to a specific libssl like how .NET Core is). I would recommend switching to it (the shell script does a simple find/replace with sed).

As well, maybe copy in the patched appmanifest? 
