### PR TITLE
Added -c to only copy files, also added confirmation for copying the files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ automatically.
 However, if the game gets updated by Steam, you will need to copy the downgraded files
 again. You can run the script with the -c option to only copy the files:
 
-$ ./doomgrader -c
+`./doomgrader -c`
 
 ## Running the game
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ found
 ## Prerequisites
 
 - A fully updated Steam version of Doom Eternal
-- .NET Core: See [here](https://wiki.archlinux.org/index.php/.NET_Core) for more
-  information. Don't forget to add `~/.dotnet/tools` to your PATH.
+- Mono: See [here](https://wiki.archlinux.org/index.php/Mono) for more information.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ found
 ## Prerequisites
 
 - A fully updated Steam version of Doom Eternal
-- Mono: See [here](https://wiki.archlinux.org/index.php/Mono) for more information.
+- .NET Core: See [here](https://wiki.archlinux.org/index.php/.NET_Core) for more
+  information. Don't forget to add `~/.dotnet/tools` to your PATH.
 
 ## Config
 
@@ -43,7 +44,7 @@ Variables must be changed by editing the script before execution
 2. Run the script `./doomgrader.sh`
 3. Enter your Steam credentials when prompted (works with Steam Guard)
 4. Wait for the download to complete (this can take a very long time)
-5. Answer the copying question when prompted (this is to ensure you don't erase files you don't want to)
+5. Confirm that you want to copy the files to your steam games directory
 
 ## Copying game files
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Variables must be changed by editing the script before execution
 2. Run the script `./doomgrader.sh`
 3. Enter your Steam credentials when prompted (works with Steam Guard)
 4. Wait for the download to complete (this can take a very long time)
+5. Answer the copying question when prompted (this is to ensure you don't erase files you don't want to)
 
 ## Copying game files
 
@@ -51,9 +52,9 @@ The script will copy the downgraded game files to your Doom Eternal path
 automatically.
 
 However, if the game gets updated by Steam, you will need to copy the downgraded files
-again. You could do that by simply running the entire script as it will not
-redownload existing files. The fastest way would be to manually copy the files.
-Eg `\cp ~/doomgrader/files/* ~/.steam/steam/steamapps/common/DOOMEternal/ -rf`
+again. You can run the script with the -c option to only copy the files:
+
+$ ./doomgrader -c
 
 ## Running the game
 

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -10,33 +10,47 @@ STEAM_PATH=/run/media/nvme/SteamLibrary/steamapps/common/
 DOWNLOAD_PATH=$DOOMGRADER_ROOT/files
 DEPOTDOWNLOADER_PATH=$DOOMGRADER_ROOT/depotdownloader
 
-# prompt for steam credentials
-IFS=$'\n' # handle spaces in passwords
-read -p "Enter your Steam username:" STEAM_USERNAME
-read -s -p "Enter your Steam password:" STEAM_PASSWORD
+# if statement to help skip downloading if not needed
+if [[ $1 != "-c" ]]
+then
+    
+    # prompt for steam credentials
+    IFS=$'\n' # handle spaces in passwords
+    read -p "Enter your Steam username:" STEAM_USERNAME
+    read -s -p "Enter your Steam password:" STEAM_PASSWORD
 
-# make doomgrader directories
-mkdir -p $DOOMGRADER_ROOT $DOWNLOAD_PATH $DEPOTDOWNLOADER_PATH
+    # make doomgrader directories
+    mkdir -p $DOOMGRADER_ROOT $DOWNLOAD_PATH $DEPOTDOWNLOADER_PATH
 
-# change to depotdownloader directory
-pushd $DEPOTDOWNLOADER_PATH
+    # change to depotdownloader directory
+    pushd $DEPOTDOWNLOADER_PATH
 
-# download depotdownloader
-wget https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/depotdownloader-2.3.4.zip -O depotdownloader_2.3.4.zip
+    # download depotdownloader
+    wget https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/depotdownloader-2.3.4.zip -O depotdownloader_2.3.4.zip
 
-# extract depotdownloader
-unzip depotdownloader_2.3.4.zip
+    # extract depotdownloader
+    unzip depotdownloader_2.3.4.zip
 
-# make depotdownloader executable
-chmod +x depotdownloader
+    # make depotdownloader executable
+    chmod +x depotdownloader
 
-# download the depots
-./depotdownloader -app 782330 -depot 782332 -manifest 4641765937586464647 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-./depotdownloader -app 782330 -depot 782333 -manifest 4686311672633195957 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-./depotdownloader -app 782330 -depot 782334 -manifest 2624212357815850298 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-./depotdownloader -app 782330 -depot 782335 -manifest 8671913471625122045 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-./depotdownloader -app 782330 -depot 782336 -manifest 4248922069342282231 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-./depotdownloader -app 782330 -depot 782339 -manifest 8937962102049582968 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+    # download the depots
+    ./depotdownloader -app 782330 -depot 782332 -manifest 4641765937586464647 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+    ./depotdownloader -app 782330 -depot 782333 -manifest 4686311672633195957 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+    ./depotdownloader -app 782330 -depot 782334 -manifest 2624212357815850298 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+    ./depotdownloader -app 782330 -depot 782335 -manifest 8671913471625122045 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+    ./depotdownloader -app 782330 -depot 782336 -manifest 4248922069342282231 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+    ./depotdownloader -app 782330 -depot 782339 -manifest 8937962102049582968 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+
+fi
 
 # copy game files to steam dir
-\cp $DOWNLOAD_PATH/* $STEAM_PATH/DOOMEternal/ -rf
+echo "Copying the game from $DOWNLOAD_PATH to $STEAM_PATH/DOOMEternal/"
+read -p "Is this correct (y/n)?: " DOOMGRADER_ANSWER
+
+if [[ $DOOMGRADER_ANSWER == 'Y' || $DOOMGRADER_ANSWER == "yes" || $DOOMGRADER_ANSWER == "YES" || $DOOMGRADER_ANSWER == "y" ]]
+then
+   \cp $DOWNLOAD_PATH/* $STEAM_PATH/DOOMEternal/ -rf
+else
+    echo "Copying of files stopped!"
+fi

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -3,8 +3,8 @@
 set -e
 
 # doomgrader config
-DOOMGRADER_ROOT=/run/media/nvme/.doomgrader/
-STEAM_PATH=/run/media/nvme/SteamLibrary/steamapps/common/
+DOOMGRADER_ROOT=~/doomgrader
+STEAM_PATH=~/.steam/steam/steamapps/common
 
 # internal paths
 DOWNLOAD_PATH=$DOOMGRADER_ROOT/files

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# doomgrader config
+# doomgrader config; EDIT HERE!
 DOOMGRADER_ROOT=~/doomgrader
 STEAM_PATH=~/.steam/steam/steamapps/common
 
@@ -10,49 +10,63 @@ STEAM_PATH=~/.steam/steam/steamapps/common
 DOWNLOAD_PATH=$DOOMGRADER_ROOT/files
 DEPOTDOWNLOADER_PATH=$DOOMGRADER_ROOT/depotdownloader
 
-# if statement to help skip downloading if not needed
-if [[ $1 != "-c" ]]
-then
-    
-    # prompt for steam credentials
-    IFS=$'\n' # handle spaces in passwords
-    read -p "Enter your Steam username:" STEAM_USERNAME
-    read -s -p "Enter your Steam password:" STEAM_PASSWORD
-
-    # make doomgrader directories
-    mkdir -p $DOOMGRADER_ROOT $DOWNLOAD_PATH $DEPOTDOWNLOADER_PATH
-
-    # change to depotdownloader directory
-    pushd $DEPOTDOWNLOADER_PATH
-
-    # download depotdownloader
-    curl https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/depotdownloader-2.3.4.zip -o depotdownloader_2.3.4.zip -L
-    # extract depotdownloader
-    unzip depotdownloader_2.3.4.zip
-
-    # make depotdownloader executable
-    chmod +x depotdownloader
-    # replace dotnet dependency with mono
-    sed -i 's/dotnet/mono/' depotdownloader
-
-
-    # download the depots
-    ./depotdownloader -app 782330 -depot 782332 -manifest 4641765937586464647 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-    ./depotdownloader -app 782330 -depot 782333 -manifest 4686311672633195957 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-    ./depotdownloader -app 782330 -depot 782334 -manifest 2624212357815850298 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-    ./depotdownloader -app 782330 -depot 782335 -manifest 8671913471625122045 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-    ./depotdownloader -app 782330 -depot 782336 -manifest 4248922069342282231 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-    ./depotdownloader -app 782330 -depot 782339 -manifest 8937962102049582968 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
-
-fi
-
+# function for copying files with prompt
+DOOMGRADER_COPY()
+{
 # copy game files to steam dir
 echo "Copying the game from $DOWNLOAD_PATH to $STEAM_PATH/DOOMEternal/"
+echo "THIS WILL OVERWRITE YOUR EXISTING DOOM ETERNAL GAME FILES!"
 read -p "Is this correct (y/n)?: " DOOMGRADER_ANSWER
 
 if [[ $DOOMGRADER_ANSWER == 'Y' || $DOOMGRADER_ANSWER == "yes" || $DOOMGRADER_ANSWER == "YES" || $DOOMGRADER_ANSWER == "y" ]]
 then
-   \cp $DOWNLOAD_PATH/* $STEAM_PATH/DOOMEternal/ -rf
+    cp $DOWNLOAD_PATH/* $STEAM_PATH/DOOMEternal/ -rfv
 else
     echo "Copying of files stopped!"
+    echo "No files were copied or overwritten!"
 fi
+}
+
+# if the "-c" option/flag is passed, then just do the copy and finish
+if [[ $1 == "-c" ]]
+then
+DOOMGRADER_COPY
+exit 0
+fi
+
+# handles downloading depotdownloader and downloading the old version of Doom Eternal
+# prompt for steam credentials, no need to edit in the script
+IFS=$'\n' # handle spaces in passwords
+read -p "Enter your Steam username:" STEAM_USERNAME
+read -s -p "Enter your Steam password:" STEAM_PASSWORD
+
+# make doomgrader directories
+mkdir -p $DOOMGRADER_ROOT $DOWNLOAD_PATH $DEPOTDOWNLOADER_PATH
+
+# change to depotdownloader directory
+pushd $DEPOTDOWNLOADER_PATH
+
+# download depotdownloader
+curl https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/depotdownloader-2.3.4.zip -o depotdownloader_2.3.4.zip -L
+
+# extract depotdownloader
+unzip depotdownloader_2.3.4.zip
+
+# make depotdownloader executable
+chmod +x depotdownloader
+
+# replace dotnet dependency with mono
+sed -i 's/dotnet/mono/' depotdownloader
+
+# download the depots
+./depotdownloader -app 782330 -depot 782332 -manifest 4641765937586464647 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+./depotdownloader -app 782330 -depot 782333 -manifest 4686311672633195957 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+./depotdownloader -app 782330 -depot 782334 -manifest 2624212357815850298 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+./depotdownloader -app 782330 -depot 782335 -manifest 8671913471625122045 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+./depotdownloader -app 782330 -depot 782336 -manifest 4248922069342282231 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+./depotdownloader -app 782330 -depot 782339 -manifest 8937962102049582968 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+
+# now copy the files downloaded from depotdownloader into your steam directory
+echo "" # adds space between depot downloader output and DOOMGRADER_COPY prompt
+DOOMGRADER_COPY
+

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -66,7 +66,9 @@ sed -i 's/dotnet/mono/' depotdownloader
 ./depotdownloader -app 782330 -depot 782336 -manifest 4248922069342282231 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 ./depotdownloader -app 782330 -depot 782339 -manifest 8937962102049582968 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 
+# adds space between depot downloader output and DOOMGRADER_COPY prompt
+echo ""
+
 # now copy the files downloaded from depotdownloader into your steam directory
-echo "" # adds space between depot downloader output and DOOMGRADER_COPY prompt
 DOOMGRADER_COPY
 

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# doomgrader config; EDIT HERE!
+# doomgrader config, edit DOOMGRADER_ROOT and STEAM_PATH
 DOOMGRADER_ROOT=~/doomgrader
 STEAM_PATH=~/.steam/steam/steamapps/common
 
@@ -11,30 +11,28 @@ DOWNLOAD_PATH=$DOOMGRADER_ROOT/files
 DEPOTDOWNLOADER_PATH=$DOOMGRADER_ROOT/depotdownloader
 
 # function for copying files with prompt
-DOOMGRADER_COPY()
+copy()
 {
-# copy game files to steam dir
 echo "Copying the game from $DOWNLOAD_PATH to $STEAM_PATH/DOOMEternal/"
-echo "THIS WILL OVERWRITE YOUR EXISTING DOOM ETERNAL GAME FILES!"
+echo "This will OVERWRITE your existing Doom Eternal game files"
 read -p "Is this correct (y/n)?: " DOOMGRADER_ANSWER
 
 if [[ $DOOMGRADER_ANSWER == 'Y' || $DOOMGRADER_ANSWER == "yes" || $DOOMGRADER_ANSWER == "YES" || $DOOMGRADER_ANSWER == "y" || $DOOMGRADER_ANSWER == "Yes" ]]
 then
-    cp $DOWNLOAD_PATH/* $STEAM_PATH/DOOMEternal/ -rfv
+    \cp $DOWNLOAD_PATH/* $STEAM_PATH/DOOMEternal/ -rfv
 else
-    echo "Copying of files stopped!"
-    echo "No files were copied or overwritten!"
+    echo "Copying of files stopped"
+    echo "No files were copied or overwritten"
 fi
 }
 
 # if the "-c" option/flag is passed, then just do the copy and finish
 if [[ $1 == "-c" ]]
 then
-DOOMGRADER_COPY
+copy
 exit 0
 fi
 
-# handles downloading depotdownloader and downloading the old version of Doom Eternal
 # prompt for steam credentials, no need to edit in the script
 IFS=$'\n' # handle spaces in passwords
 read -p "Enter your Steam username:" STEAM_USERNAME
@@ -66,9 +64,9 @@ sed -i 's/dotnet/mono/' depotdownloader
 ./depotdownloader -app 782330 -depot 782336 -manifest 4248922069342282231 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 ./depotdownloader -app 782330 -depot 782339 -manifest 8937962102049582968 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 
-# adds space between depot downloader output and DOOMGRADER_COPY prompt
+# adds space between depot downloader output and copy prompt
 echo ""
 
 # now copy the files downloaded from depotdownloader into your steam directory
-DOOMGRADER_COPY
+copy
 

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -18,7 +18,7 @@ echo "Copying the game from $DOWNLOAD_PATH to $STEAM_PATH/DOOMEternal/"
 echo "THIS WILL OVERWRITE YOUR EXISTING DOOM ETERNAL GAME FILES!"
 read -p "Is this correct (y/n)?: " DOOMGRADER_ANSWER
 
-if [[ $DOOMGRADER_ANSWER == 'Y' || $DOOMGRADER_ANSWER == "yes" || $DOOMGRADER_ANSWER == "YES" || $DOOMGRADER_ANSWER == "y" ]]
+if [[ $DOOMGRADER_ANSWER == 'Y' || $DOOMGRADER_ANSWER == "yes" || $DOOMGRADER_ANSWER == "YES" || $DOOMGRADER_ANSWER == "y" || $DOOMGRADER_ANSWER == "Yes" ]]
 then
     cp $DOWNLOAD_PATH/* $STEAM_PATH/DOOMEternal/ -rfv
 else

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -3,8 +3,8 @@
 set -e
 
 # doomgrader config
-DOOMGRADER_ROOT=~/doomgrader
-STEAM_PATH=~/.steam/steam/steamapps/common
+DOOMGRADER_ROOT=/run/media/nvme/.doomgrader/
+STEAM_PATH=/run/media/nvme/SteamLibrary/steamapps/common/
 
 # internal paths
 DOWNLOAD_PATH=$DOOMGRADER_ROOT/files


### PR DESCRIPTION
This will add a -c option to the script, so you can skip the download checks and putting in your steam credentials. 

There is also a prompt that shows where the files are copying from and to, to make sure that cp -rf is happening where and to you think they will.

README has also been updated to reflect these changes.