### PR TITLE
Added support for Windows

### DIFF
--- a/doomgrader.ps1
+++ b/doomgrader.ps1
@@ -1,0 +1,43 @@
+$ZIP_NAME = "depotdownloader-2.3.4.zip"
+$DEPO_DOWNLOADER_PATH = "depotdownloader"
+
+$DOOM_ETERNAL_APP_ID = "782330"
+$DEPOT__WINDOWS_EXECUTABLE = "782332"
+$DEPOT__CONFIGS = "782333"
+$DEPOT__SOUND = "782334"
+$DEPOT__VIDEO = "782335"
+$DEPOT__GAME_RESOURCES = "782336"
+$DEPOT__LAUNCHER = "782339"
+
+$game_path = Read-Host 'Enter a path for the game files'
+$username = Read-Host 'Enter your Steam username'
+$password = Read-Host 'Enter your Steam password' -AsSecureString
+
+If (-Not (Test-Path -Path $DEPO_DOWNLOADER_PATH) -And -Not (Test-Path $ZIP_NAME)) {
+    Write-Output "Downloading depodownloader"
+    Invoke-WebRequest -Uri https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/$ZIP_NAME -OutFile $ZIP_NAME
+}
+else {
+    Write-Output "Found depodownloader zip or installation; skipping download"
+}
+If (-Not (Test-Path $DEPO_DOWNLOADER_PATH)) {
+    Write-Output "Unzipping $ZIP_NAME"
+    Expand-Archive -Path $ZIP_NAME -DestinationPath $DEPO_DOWNLOADER_PATH
+}
+else {
+    Write-Output "Found depodownloader installation; skipping unzip"
+}
+
+Write-Output "Creating $game_path if it does not already exist"
+New-Item -Path $game_path -ItemType directory -Force
+
+function FetchDowngrade($depot, $manifest) {
+    DotNet ./$DEPO_DOWNLOADER_PATH/DepotDownloader.dll -app $DOOM_ETERNAL_APP_ID -depot $depot -manifest $manifest -username $username -password $password -dir $game_path
+}
+
+FetchDowngrade -depot $DEPOT__WINDOWS_EXECUTABLE -manifest 4641765937586464647
+FetchDowngrade -depot $DEPOT__CONFIGS -manifest 4686311672633195957
+FetchDowngrade -depot $DEPOT__SOUND -manifest 2624212357815850298
+FetchDowngrade -depot $DEPOT__VIDEO -manifest 8671913471625122045
+FetchDowngrade -depot $DEPOT__GAME_RESOURCES -manifest 4248922069342282231
+FetchDowngrade -depot $DEPOT__LAUNCHER -manifest 8937962102049582968

--- a/doomgrader.ps1
+++ b/doomgrader.ps1
@@ -12,7 +12,7 @@ $DEPOT__GAME_RESOURCES = "782336"
 $DEPOT__LAUNCHER = "782339"
 
 $download_path = Read-Host 'Enter a path for downloaded depots (optional)'
-if ([string]::IsNullOrWhiteSpace($download_path)) {
+If ([string]::IsNullOrWhiteSpace($download_path)) {
     $download_path = $DEFAULT_DEPO_PATH
 }
 $install_path = Read-Host 'Enter the path to your Doom Eternal installation'
@@ -23,14 +23,14 @@ If (-Not (Test-Path -Path $DEPO_DOWNLOADER_PATH) -And -Not (Test-Path $ZIP_NAME)
     Write-Output "Downloading depodownloader"
     Invoke-WebRequest -Uri $RELEASE_URL/$ZIP_NAME -OutFile $ZIP_NAME
 }
-else {
+Else {
     Write-Output "Found depodownloader zip or installation; skipping download"
 }
 If (-Not (Test-Path $DEPO_DOWNLOADER_PATH)) {
     Write-Output "Unzipping $ZIP_NAME"
     Expand-Archive -Path $ZIP_NAME -DestinationPath $DEPO_DOWNLOADER_PATH
 }
-else {
+Else {
     Write-Output "Found depodownloader installation; skipping unzip"
 }
 

--- a/doomgrader.ps1
+++ b/doomgrader.ps1
@@ -1,5 +1,7 @@
+$RELEASE_URL = "https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4"
 $ZIP_NAME = "depotdownloader-2.3.4.zip"
 $DEPO_DOWNLOADER_PATH = "depotdownloader"
+$DEFAULT_DEPO_PATH = "depos"
 
 $DOOM_ETERNAL_APP_ID = "782330"
 $DEPOT__WINDOWS_EXECUTABLE = "782332"
@@ -9,13 +11,17 @@ $DEPOT__VIDEO = "782335"
 $DEPOT__GAME_RESOURCES = "782336"
 $DEPOT__LAUNCHER = "782339"
 
-$game_path = Read-Host 'Enter a path for the game files'
+$download_path = Read-Host 'Enter a path for downloaded depots (optional)'
+if ([string]::IsNullOrWhiteSpace($download_path)) {
+    $download_path = $DEFAULT_DEPO_PATH
+}
+$install_path = Read-Host 'Enter the path to your Doom Eternal installation'
 $username = Read-Host 'Enter your Steam username'
-$password = Read-Host 'Enter your Steam password' -AsSecureString
+$securedPassword = Read-Host 'Enter your Steam password' -AsSecureString
 
 If (-Not (Test-Path -Path $DEPO_DOWNLOADER_PATH) -And -Not (Test-Path $ZIP_NAME)) {
     Write-Output "Downloading depodownloader"
-    Invoke-WebRequest -Uri https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_2.3.4/$ZIP_NAME -OutFile $ZIP_NAME
+    Invoke-WebRequest -Uri $RELEASE_URL/$ZIP_NAME -OutFile $ZIP_NAME
 }
 else {
     Write-Output "Found depodownloader zip or installation; skipping download"
@@ -28,16 +34,29 @@ else {
     Write-Output "Found depodownloader installation; skipping unzip"
 }
 
-Write-Output "Creating $game_path if it does not already exist"
-New-Item -Path $game_path -ItemType directory -Force
+Write-Output "Creating $download_path if it does not already exist"
+New-Item -Path $download_path -ItemType directory -Force
 
 function FetchDowngrade($depot, $manifest) {
-    DotNet ./$DEPO_DOWNLOADER_PATH/DepotDownloader.dll -app $DOOM_ETERNAL_APP_ID -depot $depot -manifest $manifest -username $username -password $password -dir $game_path
+    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securedPassword)
+    $password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+    DotNet ./$DEPO_DOWNLOADER_PATH/DepotDownloader.dll `
+        -app $DOOM_ETERNAL_APP_ID `
+        -depot $depot -manifest $manifest `
+        -username $username -password $password -remember-password `
+        -dir $download_path
 }
 
-FetchDowngrade -depot $DEPOT__WINDOWS_EXECUTABLE -manifest 4641765937586464647
-FetchDowngrade -depot $DEPOT__CONFIGS -manifest 4686311672633195957
-FetchDowngrade -depot $DEPOT__SOUND -manifest 2624212357815850298
-FetchDowngrade -depot $DEPOT__VIDEO -manifest 8671913471625122045
-FetchDowngrade -depot $DEPOT__GAME_RESOURCES -manifest 4248922069342282231
-FetchDowngrade -depot $DEPOT__LAUNCHER -manifest 8937962102049582968
+FetchDowngrade -depot $DEPOT__WINDOWS_EXECUTABLE -manifest "4641765937586464647"
+FetchDowngrade -depot $DEPOT__CONFIGS -manifest "4686311672633195957"
+FetchDowngrade -depot $DEPOT__SOUND -manifest "2624212357815850298"
+FetchDowngrade -depot $DEPOT__VIDEO -manifest "8671913471625122045"
+FetchDowngrade -depot $DEPOT__GAME_RESOURCES -manifest "4248922069342282231"
+FetchDowngrade -depot $DEPOT__LAUNCHER -manifest "8937962102049582968"
+
+Write-Output "Clearing install folder ($install_path) before copying"
+Remove-Item -Path $install_path -Recurse -Force
+New-Item -Path $install_path -ItemType directory -Force
+
+Write-Output "Copying game files from $download_path to $install_path"
+Copy-Item -Path $download_path\* -Destination $install_path -Recurse -Force

--- a/doomgrader.ps1
+++ b/doomgrader.ps1
@@ -54,9 +54,11 @@ FetchDowngrade -depot $DEPOT__VIDEO -manifest "8671913471625122045"
 FetchDowngrade -depot $DEPOT__GAME_RESOURCES -manifest "4248922069342282231"
 FetchDowngrade -depot $DEPOT__LAUNCHER -manifest "8937962102049582968"
 
-Write-Output "Clearing install folder ($install_path) before copying"
-Remove-Item -Path $install_path -Recurse -Force
-New-Item -Path $install_path -ItemType directory -Force
-
-Write-Output "Copying game files from $download_path to $install_path"
-Copy-Item -Path $download_path\* -Destination $install_path -Recurse -Force
+Write-Output "WARNING: Doom Eternal must be installed through Steam before the next step!"
+$proceed = Read-Host "Enter 'yes' to start copying files to $install_path"
+If ($proceed.Equals("yes")) {
+    Write-Output "Copying game files from $download_path to $install_path"
+    Copy-Item -Path $download_path\* -Destination $install_path -Recurse -Force
+} Else {
+    Write-Output "Aborting"
+}


### PR DESCRIPTION
This is on the last stage of testing--making sure it properly copies ALL of the depots to the install directory instead of just two of the smaller ones. Otherwise, the README still needs to be updated.

You may want to reject this PR altogether if you don't want to adopt and then be on the hook for maintaining a PS1 script. If so I am willing to properly separate this fork out into its own project.