### PR TITLE
Fully downgrade all game files

### DIFF
--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -62,6 +62,8 @@ sed -i 's/dotnet/mono/' depotdownloader
 ./depotdownloader -app 782330 -depot 782334 -manifest 2624212357815850298 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 ./depotdownloader -app 782330 -depot 782335 -manifest 8671913471625122045 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 ./depotdownloader -app 782330 -depot 782336 -manifest 4248922069342282231 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+./depotdownloader -app 782330 -depot 782337 -manifest 122337607158713695 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
+./depotdownloader -app 782330 -depot 782338 -manifest 4899404039317730890 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 ./depotdownloader -app 782330 -depot 782339 -manifest 8937962102049582968 -username "$STEAM_USERNAME" -password "$STEAM_PASSWORD" -remember-password -dir "$DOWNLOAD_PATH"
 
 # adds space between depot downloader output and copy prompt


### PR DESCRIPTION
Protects against future game updates by downgrading all game files. This will result in a slightly larger download (~50GB) but should work for any future version of the base game. Addresses https://github.com/lpww/doomgrader/issues/13