### PR TITLE
Basic Dockerfile in case mono is not available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+RUN apt-get update \
+ && apt-get install -y gnupg ca-certificates \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+ && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list \
+ && apt-get update \
+ && apt-get install -y -q --no-install-recommends mono-devel curl unzip
+ADD . /doomgrader
+WORKDIR /doomgrader
+ENV STEAM_PATH=/steam
+ENV DOOMGRADER_ROOT=/data
+CMD ./doomgrader.sh

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Variables should be changed by editing the script before execution
 4. Wait for the download to complete (this can take a very long time)
 5. Confirm that you want to copy the files to your steam games directory
 
+Alternatively, if you have problems with Mono versions or errors relating to assemblies,
+there is a Dockerfile which would allow you to run the script in a container:
+
+```
+docker build -t doomgrader .
+docker run -ti -v /your/steam/files:/steam -v /temporary/doomgrader/files:/data doomgrader
+```
+
 ## Copying game files
 
 The script will copy the downgraded game files to your Doom Eternal path

--- a/doomgrader.sh
+++ b/doomgrader.sh
@@ -3,8 +3,8 @@
 set -e
 
 # optional doomgrader config, only edit DOOMGRADER_ROOT and STEAM_PATH
-DOOMGRADER_ROOT=~/doomgrader
-STEAM_PATH=~/.steam/steam/steamapps/common
+DOOMGRADER_ROOT=${DOOMGRADER_ROOT:-~/doomgrader}
+STEAM_PATH=${STEAM_PATH:-~/.steam/steam/steamapps/common}
 
 # internal paths
 DOWNLOAD_PATH=$DOOMGRADER_ROOT/files


### PR DESCRIPTION
Support for running the script in `docker`, mostly intended for cases where mono isn't working, or you don't want to install the mono runtime just to run this script.